### PR TITLE
Fix Regex 2 in Module4.mdx

### DIFF
--- a/pages/Modules/Module4.mdx
+++ b/pages/Modules/Module4.mdx
@@ -40,10 +40,11 @@ import { Steps, Callout } from 'nextra/components'
   - 元音字母有 `a、e、i、o、u`。
   - 使用字符类 `[aeiouAEIOU]` 匹配任意一个元音字母。
   - 使用量词 `{3,}` 表示匹配三个或更多。
+  - 使用 `\w*` 去匹配连续元音前后的 0 到更多个字母
 
   **答案：**
   ```regex copy
-  [aeiouAEIOU]{3,}
+  \w*[aeiouAEIOU]{3,}\w*
   ```
 
 - **正则表达式 3**


### PR DESCRIPTION
According to the examples on the website, Regex 2 should match the **entire word**, not just parts of it (?) . Updated the regex to reflect this behavior.
<img width="1136" alt="image" src="https://github.com/user-attachments/assets/c0704b44-6841-42e4-99ad-70434ad7adad">


[module4](https://classes.engineering.wustl.edu/cse330/index.php?title=Module_4)